### PR TITLE
chore: remove changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-## 0.0.2
-* Simplify `/podium` by removing `tournamentUrl` and `type` parameters
-
-## 0.0.1
-* Add `/ping` command
-* Add `/podio` command
-* Separate DEV and PROD workflows


### PR DESCRIPTION
Github has a changelog generation feature on releases page. We should use them, instead of making manual insertions on changelog.